### PR TITLE
Fix package imports for tests

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,2 @@
+# Package marker for src modules.
+# This allows importing modules using the `src` package namespace.

--- a/tests/src/__init__.py
+++ b/tests/src/__init__.py
@@ -1,0 +1,3 @@
+"""Proxy package to expose the project's `src` modules for tests."""
+import os
+__path__ = [os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'src'))]


### PR DESCRIPTION
## Summary
- make `src` a proper Python package
- allow tests to resolve `src` modules without installing the package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fa8243258832f885c81aa2024813b